### PR TITLE
Add logging with --debug flag

### DIFF
--- a/src/reverb_alerts/parser.py
+++ b/src/reverb_alerts/parser.py
@@ -1,8 +1,12 @@
+import logging
+
 from pydantic import BaseModel
 from pydantic_ai import Agent
 
 from reverb_alerts.config import Watch
 from reverb_alerts.models import ReverbListing
+
+logger = logging.getLogger(__name__)
 
 
 class ListingResults(BaseModel):
@@ -30,11 +34,14 @@ def _get_agent() -> Agent[None, ListingResults]:
 
 def parse_listings(markdown: str) -> list[ReverbListing]:
     agent = _get_agent()
+    logger.info("Parsing listings with PydanticAI agent")
     result = agent.run_sync(f"Extract all listings from this Reverb marketplace page:\n\n{markdown}")
+    logger.info("Extracted %d listing(s)", len(result.output.listings))
     return result.output.listings
 
 
 def filter_listings(listings: list[ReverbListing], watch: Watch) -> list[ReverbListing]:
+    logger.debug("Filtering %d listings for watch '%s'", len(listings), watch.name)
     matches = []
     for listing in listings:
         effective_price = listing.price

--- a/src/reverb_alerts/scraper.py
+++ b/src/reverb_alerts/scraper.py
@@ -1,7 +1,10 @@
+import logging
 import os
 from urllib.parse import quote
 
 from firecrawl import FirecrawlApp
+
+logger = logging.getLogger(__name__)
 
 
 def scrape_reverb(query: str, location: str | None = None) -> str | None:
@@ -11,6 +14,8 @@ def scrape_reverb(query: str, location: str | None = None) -> str | None:
     if location:
         url += f"&item_region={quote(location)}"
 
+    logger.info("Scraping %s", url)
     result = app.scrape(url, formats=["markdown"])
+    logger.debug("Firecrawl response length: %d chars", len(result.markdown or ""))
 
     return result.markdown


### PR DESCRIPTION
## Summary
- Add structured logging to scraper (Firecrawl request URLs, response sizes) and parser (extraction counts, filtering)
- Silence httpx/httpcore loggers by default, enable with `--debug`
- New `--debug` CLI flag for verbose output

## Test plan
- [ ] Run `uv run reverb-alerts --dry-run` — should show INFO-level logs (scrape URLs, listing counts)
- [ ] Run `uv run reverb-alerts --dry-run --debug` — should show DEBUG-level logs including httpx traffic
- [ ] Run without `--debug` — confirm no httpx noise in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)