### PR TITLE
Add exclude terms and improve product relevance

### DIFF
--- a/src/reverb_alerts/cli.py
+++ b/src/reverb_alerts/cli.py
@@ -42,7 +42,7 @@ def main(config_path: str, mode: str | None, debug: bool) -> None:
         click.echo(f"Checking: {watch.name} (max ${watch.max_price:.2f})...")
 
         markdown = scrape_reverb(watch.query, watch.max_price, watch.location, watch.conditions)
-        listings = parse_listings(markdown)
+        listings = parse_listings(markdown, watch.query)
         matches = filter_listings(listings, watch)
 
         if not matches:

--- a/src/reverb_alerts/config.py
+++ b/src/reverb_alerts/config.py
@@ -13,6 +13,7 @@ class Watch(BaseModel):
     include_shipping: bool = False
     location: str | None = None
     conditions: list[ReverbCondition] | None = None
+    exclude_terms: list[str] | None = None
 
 
 class WatchConfig(BaseModel):

--- a/watches.yaml
+++ b/watches.yaml
@@ -8,3 +8,7 @@ watches:
       - "Very Good"
       - "Excellent"
       - "Mint"
+    exclude_terms:
+      - "XL"
+      - "One"
+      - "Effects"


### PR DESCRIPTION
## Summary
- Pass the watch query to the PydanticAI agent so it can accurately classify primary products vs unrelated items from the same brand
- Add `exclude_terms` config option with word boundary regex matching to filter out known non-matching variants (e.g. XL, One, Effects)
- Configure HX Stomp watch with exclude terms and $400 max price

## Test plan
- [x] Dry run confirmed: all non-HX-Stomp products (POD Go, HX Effects, HX One, DL4, Relay) correctly filtered out
- [x] Verify workflow runs successfully on schedule